### PR TITLE
Update xwiki-commons-tool-extension-plugin to allow build with Maven 3.9

### DIFF
--- a/macro-jwplayer-xip/pom.xml
+++ b/macro-jwplayer-xip/pom.xml
@@ -48,6 +48,7 @@
         <plugin>
           <groupId>org.xwiki.commons</groupId>
           <artifactId>xwiki-commons-tool-extension-plugin</artifactId>
+          <!-- Using a more recent version of the plugin to make the build compatible with Maven 3.9. See https://github.com/xwiki/xwiki-commons/commit/067d23ddb55c2b9335eca8e6b675a54da5f43dc1 -->
           <version>15.2</version>
           <configuration>
             <coreExtensions>

--- a/macro-jwplayer-xip/pom.xml
+++ b/macro-jwplayer-xip/pom.xml
@@ -48,7 +48,7 @@
         <plugin>
           <groupId>org.xwiki.commons</groupId>
           <artifactId>xwiki-commons-tool-extension-plugin</artifactId>
-          <version>${commons.version}</version>
+          <version>15.2</version>
           <configuration>
             <coreExtensions>
               <!-- We exclude what is already in the WAR. -->

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.xwiki.contrib</groupId>
     <artifactId>parent-platform</artifactId>
-    <version>9.5</version>
+    <version>9.8.1</version>
   </parent>
   <artifactId>macro-jwplayer</artifactId>
   <version>2.1.11-SNAPSHOT</version>


### PR DESCRIPTION
Based on https://github.com/xwiki/xwiki-commons/commit/067d23ddb55c2b9335eca8e6b675a54da5f43dc1 version `15.2` is required to ensure compatibility with Maven `3.9.0` (also see https://issues.apache.org/jira/browse/MRESOLVER-151?focusedCommentId=17692755&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-17692755).

Also update `parent-platform` to `9.8.1` to benefit from https://jira.xwiki.org/browse/XCOMMONS-1230.